### PR TITLE
Move fakerest in prod dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,11 +29,13 @@
     "url": "https://github.com/marmelab/aor-json-rest-client/issues"
   },
   "homepage": "https://github.com/marmelab/aor-json-rest-client#readme",
+  "dependencies": {
+    "fakerest": "~1.2.1"
+  },
   "devDependencies": {
     "babel-cli": "^6.18.0",
     "babel-plugin-add-module-exports": "^0.2.1",
     "babel-preset-es2015": "^6.18.0",
-    "babel-preset-stage-0": "^6.16.0",
-    "fakerest": "~1.2.1"
+    "babel-preset-stage-0": "^6.16.0"
   }
 }


### PR DESCRIPTION
Indeed, when installing admin-on-rest, we get the following error otherwise:

```
ERROR in ./~/aor-json-rest-client/lib/index.js
Module not found: Error: Cannot resolve module 'fakerest' in /home/jpetitcolas/dev/admin-on-rest/example/node_modules/aor-json-rest-client/lib
 @ ./~/aor-json-rest-client/lib/index.js 9:16-35
```

Which seems legit. Indeed, this dependency is used directly in [index.js](https://github.com/marmelab/aor-json-rest-client/blob/master/src/index.js#L1).